### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Image System Engineering Toolbox for Biology - ISETBio - is a Matlab toolbox for calculating the properties of the front end of the visual system.  The toolbox begins with a description of the scene radiance, how the radiance is transformed by the optics into the retinal image, captured of light by the photopigment, the photocurrent responses in the receptors.  We are actively working on modeling how the photoreceptor signals are converted into retinal ganglion cell responses.
 
-This repository includes a [WIKI](https://github.com/isetbio/isetbio/wiki) that describes the software as well as many examples of how to perform computations to calculate the visual encoding of light in the eye.  The [WIKI](https://github.com/isetbio/isetbio/wiki) also describes tools to quantify, view and and analyze the information contained at different neural stages.  
+This repository includes a [WIKI](https://github.com/isetbio/isetbio/wiki) that describes the software as well as many examples of how to perform computations to calculate the visual encoding of light in the eye.  The [WIKI](https://github.com/isetbio/isetbio/wiki) also describes tools to quantify, view and analyze the information contained at different neural stages.  
 
 As of May 27, 2024 To run ISETBio, you must download ISETCam and have it on your Matlab path.  See installing [ISETCam](https://github.com/iset/isetcam/wiki). 
 


### PR DESCRIPTION
## Summary
- fix a duplicated word in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68510d4f727883209f462b8138e8b551